### PR TITLE
Add sort to file_list array.

### DIFF
--- a/lib/capybara-differ.rb
+++ b/lib/capybara-differ.rb
@@ -77,7 +77,7 @@ module Capybara
       save_page(filename)
 
       base_dir = File.join([Capybara.save_path, path_from_name].compact)
-      file_list = Dir[File.join(base_dir, '*.html')]
+      file_list = Dir[File.join(base_dir, '*.html')].sort
       old_html_path = options[:compare_with] == :previous ? file_list[-2] : file_list.first
       new_html_path = file_list.last
 


### PR DESCRIPTION
This was a known issue from my previous experience with the gem. My bash/console may be sorting the elements in the array based on `updated_at` (something other than `name`, which was expected.)

This caused the diff to show reversed colors (Red `++`/additions, green `--`/removal).